### PR TITLE
Expose bulk setTraits

### DIFF
--- a/FlagsmithClient/Classes/Flagsmith+Concurrency.swift
+++ b/FlagsmithClient/Classes/Flagsmith+Concurrency.swift
@@ -142,6 +142,25 @@ public extension Flagsmith {
       }
     })
   }
+
+  /// Set user traits in bulk for provided identity
+  ///
+  /// - Parameters:
+  ///   - trait: Traits to be created or updated
+  ///   - identity: ID of the user
+  /// - returns: The Traits requested to be set.
+  @discardableResult func setTraits(_ traits: [Trait], forIdentity identity: String) async throws -> [Trait] {
+      try await withCheckedThrowingContinuation({ continuation in
+          setTraits(traits, forIdentity: identity) { result in
+              switch result {
+              case .failure(let error):
+                  continuation.resume(throwing: error)
+              case .success(let value):
+                  continuation.resume(returning: value)
+              }
+          }
+      })
+  }
   
   /// Get both feature flags and user traits for the provided identity
   ///

--- a/FlagsmithClient/Classes/Flagsmith.swift
+++ b/FlagsmithClient/Classes/Flagsmith.swift
@@ -189,6 +189,20 @@ public class Flagsmith {
       completion(result)
     }
   }
+
+  /// Set user traits in bulk for provided identity
+  ///
+  /// - Parameters:
+  ///   - traits: Traits to be created or updated
+  ///   - identity: ID of the user
+  ///   - completion: Closure with Result which contains Traits in case of success or Error in case of failure
+  public func setTraits(_ traits: [Trait],
+                        forIdentity identity: String,
+                        completion: @escaping (Result<[Trait], Error>) -> Void) {
+    apiManager.request(.postTraits(identity: identity, traits: traits)) { (result: Result<[Trait], Error>) in
+      completion(result)
+    }
+  }
   
   /// Get both feature flags and user traits for the provided identity
   ///


### PR DESCRIPTION
https://github.com/Flagsmith/flagsmith-ios-client/pull/24 did add the ability to bulk upload traits.
Sadly it did not expose that ability to the user. 
This PR adds a `setTraits` API for that.