### PR TITLE
Defaults and cache

### DIFF
--- a/Example/FlagsmithClient.xcodeproj/project.pbxproj
+++ b/Example/FlagsmithClient.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		DAED1E8E268DBF9100F91DBC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		DAED1E90268DBF9100F91DBC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		DAED1E91268DBF9100F91DBC /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		DAED1E92268DBF9100F91DBC /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		DAED1E92268DBF9100F91DBC /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/Example/FlagsmithClient/AppDelegate.swift
+++ b/Example/FlagsmithClient/AppDelegate.swift
@@ -26,7 +26,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     // set cache on / off (defaults to on)
     Flagsmith.shared.useCache = true
-    
+
+    // set skip API on / off (defaults to off)
+    Flagsmith.shared.skipAPI = false
+
+    // set cache TTL in seconds (defaults to 0, i.e. infinite)
+    Flagsmith.shared.cacheTTL = 0
+
     // set analytics on or off
     Flagsmith.shared.enableAnalytics = true
     

--- a/Example/FlagsmithClient/AppDelegate.swift
+++ b/Example/FlagsmithClient/AppDelegate.swift
@@ -18,6 +18,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     Flagsmith.shared.apiKey = "<add your API key from the Flagsmith settings page>"
+      
+    // set default flags
+    Flagsmith.shared.defaultFlags = [Flag(featureName: "feature_a", enabled: false),
+                                     Flag(featureName: "font_size", intValue:12, enabled: true),
+                                     Flag(featureName: "my_name", stringValue:"Testing", enabled: true)]
+    
+    // set cache on / off (defaults to on)
+    Flagsmith.shared.useCache = true
     
     // set analytics on or off
     Flagsmith.shared.enableAnalytics = true

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		83D44370DA79D1E1C2C20ABD98D13475 /* FlagsmithClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EF53626DB8E67CE608BFEEB08DF2A5C /* FlagsmithClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B7C44FEAEB3099494B79EA35B9F71DE0 /* FlagsmithClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C7A4CB83310920D7A2F76B1F4F715BA5 /* FlagsmithClient-dummy.m */; };
 		C5344C505516395035EAB8B9FC111FE2 /* Pods-FlagsmithClient_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F66D3EFFD8615AE149DCEEE155C049F /* Pods-FlagsmithClient_Example-dummy.m */; };
+		DA2D2B182A1BBFF200CD98D9 /* Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2D2B172A1BBFF200CD98D9 /* Traits.swift */; };
 		E119200D27E4E5CE00820B87 /* FlagsmithError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119200827E4E5CE00820B87 /* FlagsmithError.swift */; };
 		E119200E27E4E5CE00820B87 /* FlagsmithAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119200A27E4E5CE00820B87 /* FlagsmithAnalytics.swift */; };
 		E119200F27E4E5CE00820B87 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119200B27E4E5CE00820B87 /* APIManager.swift */; };
@@ -44,14 +45,14 @@
 		23348535C2523FAC4E5FD55FF5CA18AA /* FlagsmithClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FlagsmithClient.release.xcconfig; sourceTree = "<group>"; };
 		250DE57229233B0BAD273A076F108A0E /* Pods-FlagsmithClient_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FlagsmithClient_Example.release.xcconfig"; sourceTree = "<group>"; };
 		287971AEF04B8BFE50BA6B4E9CB5A76E /* Flagsmith+Concurrency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Flagsmith+Concurrency.swift"; path = "FlagsmithClient/Classes/Flagsmith+Concurrency.swift"; sourceTree = "<group>"; };
-		2DDEFBF90EE0DCCBEE1F3D989919BC4A /* Flag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Flag.swift; path = FlagsmithClient/Classes/Flag.swift; sourceTree = "<group>"; };
+		2DDEFBF90EE0DCCBEE1F3D989919BC4A /* Flag.swift */ = {isa = PBXFileReference; includeInIndex = 1; indentWidth = 2; lastKnownFileType = sourcecode.swift; name = Flag.swift; path = FlagsmithClient/Classes/Flag.swift; sourceTree = "<group>"; tabWidth = 2; };
 		2EF53626DB8E67CE608BFEEB08DF2A5C /* FlagsmithClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FlagsmithClient-umbrella.h"; sourceTree = "<group>"; };
 		368DFAE2AAAB80524EFAFD71A2C92F84 /* Pods-FlagsmithClient_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FlagsmithClient_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		3B040CFA25391975C1615BFB481B68C9 /* Pods-FlagsmithClient_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FlagsmithClient_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		68DDF334F75630BAA85571DF47D87C89 /* FlagsmithClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FlagsmithClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		69E74567D7DE2313D6054FA08CFC5940 /* FlagsmithClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FlagsmithClient-prefix.pch"; sourceTree = "<group>"; };
 		73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		757CB2DED75CA13C202204D5B88B7B9A /* Flagsmith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Flagsmith.swift; path = FlagsmithClient/Classes/Flagsmith.swift; sourceTree = "<group>"; };
+		757CB2DED75CA13C202204D5B88B7B9A /* Flagsmith.swift */ = {isa = PBXFileReference; includeInIndex = 1; indentWidth = 2; lastKnownFileType = sourcecode.swift; name = Flagsmith.swift; path = FlagsmithClient/Classes/Flagsmith.swift; sourceTree = "<group>"; tabWidth = 2; };
 		772F9BEA66F23FD7DB187ACBEB72BA93 /* UnknownTypeValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UnknownTypeValue.swift; path = FlagsmithClient/Classes/UnknownTypeValue.swift; sourceTree = "<group>"; };
 		7CB5FDC929BB21CB23FFC8143AF6322F /* FlagsmithClient.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = FlagsmithClient.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		81A815D8A0C28062CD4A8224C6883D5D /* Pods-FlagsmithClient_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-FlagsmithClient_Example.modulemap"; sourceTree = "<group>"; };
@@ -66,6 +67,7 @@
 		C1CEBBBF5F9F986FB033B56D22422A4A /* Trait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Trait.swift; path = FlagsmithClient/Classes/Trait.swift; sourceTree = "<group>"; };
 		C55271DDAE55BE2BA1AFA657FA24971A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		C7A4CB83310920D7A2F76B1F4F715BA5 /* FlagsmithClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FlagsmithClient-dummy.m"; sourceTree = "<group>"; };
+		DA2D2B172A1BBFF200CD98D9 /* Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Traits.swift; path = FlagsmithClient/Classes/Traits.swift; sourceTree = "<group>"; };
 		E119200827E4E5CE00820B87 /* FlagsmithError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FlagsmithError.swift; path = FlagsmithClient/Classes/FlagsmithError.swift; sourceTree = "<group>"; };
 		E119200A27E4E5CE00820B87 /* FlagsmithAnalytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlagsmithAnalytics.swift; sourceTree = "<group>"; };
 		E119200B27E4E5CE00820B87 /* APIManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 		1A94E973B95A4D1E5D88FED450500C7B /* FlagsmithClient */ = {
 			isa = PBXGroup;
 			children = (
+				DA2D2B172A1BBFF200CD98D9 /* Traits.swift */,
 				A8A7BD53895AF16384B78CB7116DEBD7 /* Feature.swift */,
 				2DDEFBF90EE0DCCBEE1F3D989919BC4A /* Flag.swift */,
 				757CB2DED75CA13C202204D5B88B7B9A /* Flagsmith.swift */,
@@ -338,6 +341,7 @@
 				4A510C0AE712CD782D25F2276904F827 /* Flag.swift in Sources */,
 				E190202E27E24E7600C5EE2C /* TypedValue.swift in Sources */,
 				1845D603B597C651F0EE6080EF459DBB /* Flagsmith.swift in Sources */,
+				DA2D2B182A1BBFF200CD98D9 /* Traits.swift in Sources */,
 				2C55F74AE43F34E4F3952F5B86AADBF5 /* Flagsmith+Concurrency.swift in Sources */,
 				E119200F27E4E5CE00820B87 /* APIManager.swift in Sources */,
 				E119201027E4E5CE00820B87 /* Router.swift in Sources */,

--- a/FlagsmithClient.podspec
+++ b/FlagsmithClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FlagsmithClient'
-  s.version          = '3.2.1'
+  s.version          = '3.3.0'
   s.summary          = 'iOS Client written in Swift for Flagsmith. Ship features with confidence using feature flags and remote config.'
   s.homepage         = 'https://github.com/Flagsmith/flagsmith-ios-client'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/FlagsmithClient/Classes/Feature.swift
+++ b/FlagsmithClient/Classes/Feature.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  A Feature represents a flag or remote configuration value on the server.
  */
-public struct Feature: Decodable {
+public struct Feature: Codable {
   enum CodingKeys: String, CodingKey {
     case name
     case type
@@ -26,5 +26,12 @@ public struct Feature: Decodable {
     self.name = name
     self.type = type
     self.description = description
+  }
+  
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(self.name, forKey: .name)
+      try container.encodeIfPresent(self.type, forKey: .type)
+      try container.encodeIfPresent(self.description, forKey: .description)
   }
 }

--- a/FlagsmithClient/Classes/Feature.swift
+++ b/FlagsmithClient/Classes/Feature.swift
@@ -21,4 +21,10 @@ public struct Feature: Decodable {
   public let name: String
   public let type: String?
   public let description: String?
+  
+  init(name: String, type: String?, description: String?) {
+    self.name = name
+    self.type = type
+    self.description = description
+  }
 }

--- a/FlagsmithClient/Classes/Flag.swift
+++ b/FlagsmithClient/Classes/Flag.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
 A Flag represents a feature flag on the server.
 */
-public struct Flag: Decodable {
+public struct Flag: Codable {
   enum CodingKeys: String, CodingKey {
     case feature
     case value = "feature_state_value"
@@ -20,30 +20,37 @@ public struct Flag: Decodable {
   public let feature: Feature
   public let value: TypedValue
   public let enabled: Bool
-
-  init(featureName:String, boolValue: Bool, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+    
+  public init(featureName:String, boolValue: Bool, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
     self.init(featureName: featureName, value: TypedValue.bool(boolValue), enabled: enabled, featureType: featureType, featureDescription: featureDescription)
   }
 
-  init(featureName:String, floatValue: Float, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+  public init(featureName:String, floatValue: Float, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
     self.init(featureName: featureName, value: TypedValue.float(floatValue), enabled: enabled, featureType: featureType, featureDescription: featureDescription)
   }
 
-  init(featureName:String, intValue: Int, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+  public init(featureName:String, intValue: Int, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
     self.init(featureName: featureName, value: TypedValue.int(intValue), enabled: enabled, featureType: featureType, featureDescription: featureDescription)
   }
 
-  init(featureName:String, stringValue: String, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+  public init(featureName:String, stringValue: String, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
     self.init(featureName: featureName, value: TypedValue.string(stringValue), enabled: enabled, featureType: featureType, featureDescription: featureDescription)
   }
 
-  init(featureName:String, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+  public init(featureName:String, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
     self.init(featureName: featureName, value: TypedValue.null, enabled: enabled, featureType: featureType, featureDescription: featureDescription)
   }
 
-  init(featureName:String, value: TypedValue, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+  public init(featureName:String, value: TypedValue, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
     self.feature = Feature(name: featureName, type: featureType, description: featureDescription)
     self.value = value
     self.enabled = enabled
+  }
+  
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.feature, forKey: .feature)
+    try container.encode(self.value, forKey: .value)
+    try container.encode(self.enabled, forKey: .enabled)
   }
 }

--- a/FlagsmithClient/Classes/Flag.swift
+++ b/FlagsmithClient/Classes/Flag.swift
@@ -20,4 +20,30 @@ public struct Flag: Decodable {
   public let feature: Feature
   public let value: TypedValue
   public let enabled: Bool
+
+  init(featureName:String, boolValue: Bool, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+    self.init(featureName: featureName, value: TypedValue.bool(boolValue), enabled: enabled, featureType: featureType, featureDescription: featureDescription)
+  }
+
+  init(featureName:String, floatValue: Float, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+    self.init(featureName: featureName, value: TypedValue.float(floatValue), enabled: enabled, featureType: featureType, featureDescription: featureDescription)
+  }
+
+  init(featureName:String, intValue: Int, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+    self.init(featureName: featureName, value: TypedValue.int(intValue), enabled: enabled, featureType: featureType, featureDescription: featureDescription)
+  }
+
+  init(featureName:String, stringValue: String, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+    self.init(featureName: featureName, value: TypedValue.string(stringValue), enabled: enabled, featureType: featureType, featureDescription: featureDescription)
+  }
+
+  init(featureName:String, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+    self.init(featureName: featureName, value: TypedValue.null, enabled: enabled, featureType: featureType, featureDescription: featureDescription)
+  }
+
+  init(featureName:String, value: TypedValue, enabled: Bool, featureType:String? = nil, featureDescription:String? = nil) {
+    self.feature = Feature(name: featureName, type: featureType, description: featureDescription)
+    self.value = value
+    self.enabled = enabled
+  }
 }

--- a/FlagsmithClient/Classes/Flagsmith.swift
+++ b/FlagsmithClient/Classes/Flagsmith.swift
@@ -56,7 +56,7 @@ public class Flagsmith {
   public var useCache: Bool = true
 
   private init() {
-    if let data = UserDefaults.standard.value(forKey: CACHED_FLAGS_KEY) as? Data {
+    if let data = UserDefaults.standard.object(forKey: CACHED_FLAGS_KEY) as? Data {
       if let cachedFlagsObject = try? JSONDecoder().decode([String:[Flag]].self, from: data) {
         self.cachedFlags = cachedFlagsObject
       }

--- a/FlagsmithClient/Classes/Flagsmith.swift
+++ b/FlagsmithClient/Classes/Flagsmith.swift
@@ -83,6 +83,7 @@ public class Flagsmith {
     // Skip the API call if the skipAPI boolean is true, and we have an in-date cache
     if useCache && skipAPI && !getCache(forIdentity: identity).isEmpty {
       completion(.success(self.getFlagsUsingCacheAndDefaults(flags: [], forIdentity: identity)))
+      return
     }
     
     if let identity = identity {
@@ -161,7 +162,7 @@ public class Flagsmith {
     getFeatureFlags(forIdentity: identity) { (result) in
       switch result {
       case .success(let flags):
-        var flag = flags.first(where: {$0.feature.name == id})
+        let flag = flags.first(where: {$0.feature.name == id})
         completion(.success(flag?.value.stringValue))
       case .failure(let error):
         if let flag = self.getFlagUsingCacheAndDefaults(withID: id, forIdentity: identity) {
@@ -297,7 +298,7 @@ public class Flagsmith {
     return flag
   }
 
-  /// Return an array of flag for an identity, including the cached flags (if enabled) and the default flags when they are not already present in the passed array
+  /// Return an array of flags for an identity, including the cached flags (if enabled) and the default flags when they are not already present in the passed array
   private func getFlagsUsingCacheAndDefaults(flags:[Flag], forIdentity identity: String? = nil) -> [Flag] {
     var returnFlags:[Flag] = []
     returnFlags.append(contentsOf: flags)

--- a/FlagsmithClient/Classes/Flagsmith.swift
+++ b/FlagsmithClient/Classes/Flagsmith.swift
@@ -143,7 +143,9 @@ public class Flagsmith {
       switch result {
       case .success(let flags):
         var flag = flags.first(where: {$0.feature.name == id})
-        flag = self.getFlagUsingCacheAndDefaults(withID: id, flag: flag, forIdentity: identity)
+        if flag == nil {
+          flag = self.getFlagUsingCacheAndDefaults(withID: id, forIdentity: identity)
+        }
 
         completion(.success(flag?.value.stringValue))
       case .failure(let error):
@@ -166,7 +168,9 @@ public class Flagsmith {
       switch result {
       case .success(let flags):
         var flag = flags.first(where: {$0.feature.name == id})
-        flag = self.getFlagUsingCacheAndDefaults(withID: id, flag: flag, forIdentity: identity)
+        if flag == nil {
+          flag = self.getFlagUsingCacheAndDefaults(withID: id, forIdentity: identity)
+        }
         completion(.success(flag?.value))
       case .failure(let error):
         completion(.failure(error))
@@ -258,17 +262,17 @@ public class Flagsmith {
     }
   }
   
-  /// Return a flag for a flag ID and identity, using either the cache (if enabled) or the default flag when the passed flag is nil
-  private func getFlagUsingCacheAndDefaults(withID id: String, flag:Flag?, forIdentity identity: String? = nil) -> Flag? {
-    var returnFlag = flag
-    if returnFlag == nil && self.useCache {
-      returnFlag = self.getCache(forIdentity: identity).first(where: {$0.feature.name == id})
+  /// Return a flag for a flag ID and identity, using either the cache (if enabled) or the default flags
+  private func getFlagUsingCacheAndDefaults(withID id: String, forIdentity identity: String? = nil) -> Flag? {
+    var flag:Flag?
+    if useCache {
+      flag = self.getCache(forIdentity: identity).first(where: {$0.feature.name == id})
     }
-    if returnFlag == nil {
-      returnFlag = self.defaultFlags.first(where: {$0.feature.name == id})
+    if flag == nil {
+      flag = self.defaultFlags.first(where: {$0.feature.name == id})
     }
     
-    return returnFlag
+    return flag
   }
 
   /// Return an array of flag for an identity, including the cached flags (if enabled) and the default flags when they are not already present in the passed array

--- a/FlagsmithClient/Classes/Flagsmith.swift
+++ b/FlagsmithClient/Classes/Flagsmith.swift
@@ -81,7 +81,7 @@ public class Flagsmith {
                               completion: @escaping (Result<[Flag], Error>) -> Void) {
     
     // Skip the API call if the skipAPI boolean is true, and we have an in-date cache
-    if useCache && skipAPI && !cachedFlags.isEmpty && (cacheTTL == 0 || (Date.timeIntervalSinceReferenceDate - cacheLastPopulated) < cacheTTL) {
+    if useCache && skipAPI && !getCache(forIdentity: identity).isEmpty {
       completion(.success(self.getFlagsUsingCacheAndDefaults(flags: [], forIdentity: identity)))
     }
     
@@ -342,6 +342,9 @@ public class Flagsmith {
   
   /// Get the cached flags for an identity
   private func getCache(forIdentity identity: String? = nil) -> [Flag] {
-    return self.cachedFlags[identity ?? NIL_IDENTITY_KEY] ?? []
+    if cacheTTL == 0 || (Date.timeIntervalSinceReferenceDate - cacheLastPopulated) < cacheTTL {
+      return self.cachedFlags[identity ?? NIL_IDENTITY_KEY] ?? []
+    }
+    return []
   }
 }


### PR DESCRIPTION
Adding:

 - cache: all retrieved flags are cached by identity, and if a call fails, used instead. Can be turned off as well.
 - defaults: if a call fails and there is nothing in the cache, the defaults (set in code) will be returned instead.

Can be merged alongside https://github.com/Flagsmith/flagsmith/pull/2237