### PR TITLE
Use data and lock

### DIFF
--- a/FlagsmithClient/Classes/Flagsmith.swift
+++ b/FlagsmithClient/Classes/Flagsmith.swift
@@ -12,7 +12,7 @@ import FoundationNetworking
 
 /// Manage feature flags and remote config across multiple projects,
 /// environments and organisations.
-public class Flagsmith {
+public final class Flagsmith {
   /// Shared singleton client object
   public static let shared = Flagsmith()
   private let apiManager = APIManager()
@@ -263,7 +263,7 @@ public class Flagsmith {
   }
 }
 
-public class CacheConfig {
+public final class CacheConfig {
 
   /// Cache to use when enabled, defaults to the shared app cache
   public var cache: URLCache = URLCache.shared

--- a/FlagsmithClient/Classes/Internal/APIManager.swift
+++ b/FlagsmithClient/Classes/Internal/APIManager.swift
@@ -11,8 +11,8 @@ import FoundationNetworking
 #endif
 
 /// Handles interaction with a **Flagsmith** api.
-class APIManager : NSObject, URLSessionDataDelegate {
-  
+final class APIManager : NSObject, URLSessionDataDelegate {
+
   private var session: URLSession!
   
   /// Base `URL` used for requests.
@@ -22,7 +22,7 @@ class APIManager : NSObject, URLSessionDataDelegate {
     
   // store the completion handlers and accumulated data for each task
   private var tasksToCompletionHandlers:[URLSessionDataTask:(Result<Data, Error>) -> Void] = [:]
-  private var tasksToData:[URLSessionDataTask:NSMutableData] = [:]
+  private var tasksToData:[URLSessionDataTask:Data] = [:]
   
   override init() {
     super.init()
@@ -37,7 +37,7 @@ class APIManager : NSObject, URLSessionDataDelegate {
           completion(.failure(FlagsmithError.unhandled(error)))
         }
         else {
-          let data = tasksToData[dataTask] ?? NSMutableData()
+          let data = tasksToData[dataTask] ?? Data()
           completion(.success(data as Data))
         }
       }
@@ -58,7 +58,7 @@ class APIManager : NSObject, URLSessionDataDelegate {
   }
   
   func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-    let existingData = tasksToData[dataTask] ?? NSMutableData()
+    var existingData = tasksToData[dataTask] ?? Data()
     existingData.append(data)
     tasksToData[dataTask] = existingData
   }

--- a/FlagsmithClient/Classes/Internal/APIManager.swift
+++ b/FlagsmithClient/Classes/Internal/APIManager.swift
@@ -15,6 +15,7 @@ final class APIManager : NSObject, URLSessionDataDelegate {
 
   private var session: URLSession!
   private let lock: NSLock = NSLock()
+  private let delegateQueue: OperationQueue = OperationQueue()
   
   /// Base `URL` used for requests.
   var baseURL = URL(string: "https://edge.api.flagsmith.com/api/v1/")!
@@ -28,7 +29,8 @@ final class APIManager : NSObject, URLSessionDataDelegate {
   override init() {
     super.init()
     let configuration = URLSessionConfiguration.default
-    self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: OperationQueue.main)
+    delegateQueue.maxConcurrentOperationCount = 1
+    self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: delegateQueue)
   }
   
   func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {

--- a/FlagsmithClient/Classes/Internal/FlagsmithAnalytics.swift
+++ b/FlagsmithClient/Classes/Internal/FlagsmithAnalytics.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Internal analytics for the **FlagsmithClient**
-class FlagsmithAnalytics {
+final class FlagsmithAnalytics {
   
   /// Indicates if analytics are enabled.
   var enableAnalytics: Bool = true

--- a/FlagsmithClient/Classes/Internal/Router.swift
+++ b/FlagsmithClient/Classes/Internal/Router.swift
@@ -10,7 +10,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-enum Router {
+enum Router: Sendable {
   private enum HTTPMethod: String {
     case get = "GET"
     case post = "POST"


### PR DESCRIPTION
- migrated from `NSMulatbleData` to `Data`
- marked APIManager as `final` class
- added an `NSLock` instance to the APIManager class to synchronize access to shared resources. Swift dictionary is not thread-safe and accessing it from singleton instance (```Flagsmith.shared```) can lead to race conditions.