### PR TITLE
Fix: Tone down the concurrency test to ensure running on build servers

### DIFF
--- a/FlagsmithClient/Tests/APIManagerTests.swift
+++ b/FlagsmithClient/Tests/APIManagerTests.swift
@@ -66,7 +66,7 @@ final class APIManagerTests: FlagsmithClientTestCase {
         let concurrentQueue = DispatchQueue(label: "concurrentQueue", attributes: .concurrent)
         
         var expectations:[XCTestExpectation] = [];
-        let iterations = 1000
+        let iterations = 500
         var error: FlagsmithError?
         
         for concurrentIteration in 1...iterations {
@@ -82,7 +82,7 @@ final class APIManagerTests: FlagsmithClientTestCase {
             }
         }
         
-        wait(for: expectations, timeout: 5)
+        wait(for: expectations, timeout: 10)
         // Ensure that we didn't have any errors during the process
         XCTAssertTrue(error == nil)
       


### PR DESCRIPTION
## Description

Halved the thread and doubled the timeout for our concurrency test as it wasn't completing every time on the build servers.

Doesn't require a new release of the library.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Estimated time to fix the ticket(s) or epic(s) refernced by the PR in days

1h