### PR TITLE
Privacy manifest inclusion for SPM and Cocoapods

### DIFF
--- a/Example/FlagsmithClient.xcodeproj/project.pbxproj
+++ b/Example/FlagsmithClient.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Debug;
 		};

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FlagsmithClient (3.6.0)
+  - FlagsmithClient (3.5.0)
 
 DEPENDENCIES:
   - FlagsmithClient (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FlagsmithClient: 3a96576f5a251c807e6aa0a3b0db55b3e1dfd0a3
+  FlagsmithClient: 505f315402ddf4482c3477dd4a6124ab8e63361e
 
 PODFILE CHECKSUM: 9fc876dee0cf031cae843156b0740a94b4994d8c
 

--- a/Example/Pods/Local Podspecs/FlagsmithClient.podspec.json
+++ b/Example/Pods/Local Podspecs/FlagsmithClient.podspec.json
@@ -15,6 +15,11 @@
     "tag": "3.4.0"
   },
   "social_media_url": "https://twitter.com/getflagsmith",
+  "resource_bundles": {
+    "FlagSmith_Privacy": [
+      "Classes/PrivacyInfo.xcprivacy"
+    ]
+  },
   "platforms": {
     "ios": "12.0"
   },

--- a/Example/Pods/Local Podspecs/FlagsmithClient.podspec.json
+++ b/Example/Pods/Local Podspecs/FlagsmithClient.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "FlagsmithClient",
-  "version": "3.6.0",
+  "version": "3.5.0",
   "summary": "iOS Client written in Swift for Flagsmith. Ship features with confidence using feature flags and remote config.",
   "homepage": "https://github.com/Flagsmith/flagsmith-ios-client",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/Flagsmith/flagsmith-ios-client.git",
-    "tag": "3.6.0"
+    "tag": "3.5.0"
   },
   "social_media_url": "https://twitter.com/getflagsmith",
   "resource_bundles": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FlagsmithClient (3.4.0)
+  - FlagsmithClient (3.6.0)
 
 DEPENDENCIES:
   - FlagsmithClient (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FlagsmithClient: 0f8ed4a38dec385d73cc21a64b791b39bcc8c32b
+  FlagsmithClient: 101151384696085c085d06b1c202946827e058d6
 
 PODFILE CHECKSUM: 9fc876dee0cf031cae843156b0740a94b4994d8c
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.15.2

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FlagsmithClient (3.6.0)
+  - FlagsmithClient (3.5.0)
 
 DEPENDENCIES:
   - FlagsmithClient (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FlagsmithClient: 101151384696085c085d06b1c202946827e058d6
+  FlagsmithClient: 505f315402ddf4482c3477dd4a6124ab8e63361e
 
 PODFILE CHECKSUM: 9fc876dee0cf031cae843156b0740a94b4994d8c
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,84 +7,96 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		011196679F1DBAD78B3284BB60F1CC7E /* FlagsmithAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77743E9FB921729A0C34B2CBE7A1F4CD /* FlagsmithAnalytics.swift */; };
+		0083552669FD822D4A203F429BEF6F8C /* Flag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193A8DBBF59C95D3ADE40A6CACE88317 /* Flag.swift */; };
+		145BDA8A923A4A97F7D1985125F60E67 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
+		1848829C29C5631D664CC0742A63EC33 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740BE3A9082C69EDDCE885472B239E2B /* APIManager.swift */; };
 		1D8CF59EBBFF8148D15D0EFCAAA414A2 /* Pods-FlagsmithClient_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 02E4DC32B2FC713ED935462DA9F1CBF9 /* Pods-FlagsmithClient_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		28E2C1F327F2FEFC3D6193D0E775DD16 /* Flagsmith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD71DED3359EE67BB9C921E2917DA7A /* Flagsmith.swift */; };
-		361AD17B75FDA9970FF500DEE9B88729 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7482B233360C108341B85DF6F4F296D2 /* APIManager.swift */; };
+		200C93079A049CC69CF5844427F65359 /* TypedValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E24C65212832E53CD320E489F86D56 /* TypedValue.swift */; };
+		36A99CA483CA4242032567EFEC9024E9 /* FlagsmithClient-FlagSmith_Privacy in Resources */ = {isa = PBXBuildFile; fileRef = 7F9C7D04F801E733A55ED8BA67AA84CE /* FlagsmithClient-FlagSmith_Privacy */; };
+		391C8F320DDD9EAB5996574CB69D38A6 /* Trait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1CB950A2B9D94D55201B7B8191BB83 /* Trait.swift */; };
 		3CB1981582BED249B73F39640A046EC6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
-		611EFA95BB13886C84B3692AF65E66F8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
-		6EABC9E673A27FAC4180F2F08C4F2B3D /* CachedURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D88FCDAEE505ABAF4F0C9E59BEBB6A /* CachedURLResponse.swift */; };
-		7296A208906AA3BC74014294652982CA /* FlagsmithClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ECFF7C4FBE6AA88F7F7ECDCE6B66EA2 /* FlagsmithClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		78FC3BC1E0FADEB53A278A0A4C6DA6E8 /* UnknownTypeValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC513B1FDC4FEFFA6AC514C6DA6E3329 /* UnknownTypeValue.swift */; };
-		82EA3819E558968027E9A21E8E20A4A7 /* Flagsmith+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919D3C18E297943C015F838AEEAD057F /* Flagsmith+Concurrency.swift */; };
-		90AE5624A1F9C4DAA5ED6ED01FB6AA98 /* Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7B03B15ACDBBDA718D00CF6E18D416 /* Traits.swift */; };
-		95A960387ADF0D89DD60C4E6F563455F /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66035645C7F450B9A20A5AA2F1CC43B6 /* Router.swift */; };
-		97DE10D6905CEF731DD15EB738B843DD /* Trait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB810BA1DD243ED447F96C1EC7AD63F /* Trait.swift */; };
-		A3EAECF66E99CCF1D3251DB251AE6F9D /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED101D3AAE62D955200E49181AC69EF4 /* Identity.swift */; };
-		A9DAAC7965A5F9D409F7335FC223BEE6 /* TypedValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158A52A6379630867E2111515A492DDE /* TypedValue.swift */; };
-		B9ECC98F1865D64AA4B986208D0938C1 /* FlagsmithClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B880F3CB2ABE4DB1E22B3CC5541C2D8 /* FlagsmithClient-dummy.m */; };
+		41403B5BE8BE6F8EF3DD6D51EB8A05CD /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99036F2475C7DD87269B0693A1E508D1 /* Feature.swift */; };
+		4BC792BD210D6770E120952EC1A6149F /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560A2A43C2532F9A60D40C498910BDAD /* Identity.swift */; };
+		4FB62CFD8230DFD531423AC407FFBF12 /* CachedURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDBFEFB26106F14D3ACD6A6E8DAF369 /* CachedURLResponse.swift */; };
+		7A6E9ACE7C0730D83DC68A952B450CBF /* FlagsmithError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334A531B6E779CB5BBB111407DAB389B /* FlagsmithError.swift */; };
+		8C16371FF3BD75AA8903F1364B84C902 /* Flagsmith.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30C8727FF378667687B927B401ACFC2 /* Flagsmith.swift */; };
+		976897ECFF1B33FC921C0C50A0F2A156 /* Flagsmith+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33401B963FE6A82269201D80F422B5DC /* Flagsmith+Concurrency.swift */; };
+		9A443C01EC676628F306F7E210F63CBC /* Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD44276DCF6BDE68099A5762C3E3248 /* Traits.swift */; };
+		C462C452A86C94C3B33BA403FD5102C3 /* FlagsmithAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010890F60854F25B5CF6D19BAF3B3774 /* FlagsmithAnalytics.swift */; };
 		C5344C505516395035EAB8B9FC111FE2 /* Pods-FlagsmithClient_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F66D3EFFD8615AE149DCEEE155C049F /* Pods-FlagsmithClient_Example-dummy.m */; };
-		CFC4FDB2F9D6E43C28FE902C6131C027 /* FlagsmithError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD829895C1256784784DBBFC3020A222 /* FlagsmithError.swift */; };
-		CFFE0F58344636A5789C357F2BE50820 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B77E851969A4CF4C7F75194BFC80A5B /* Feature.swift */; };
-		F0F13B1D5F547C03C257DF46C49594E4 /* Flag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC8A87D5B1A7F57E12361CE1D5E95B8 /* Flag.swift */; };
+		D804DCDEA2D5AC6CE809EC8D972B3A80 /* FlagsmithClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0E8F8144A353EF4972DA8231507159 /* FlagsmithClient-dummy.m */; };
+		E4162B22739D5F7D0728E35C4B806BB5 /* FlagsmithClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 42419C1B4BE086CC475FA111C3C7F89B /* FlagsmithClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F440E618661D6B6DB91C40AA067EE9AE /* UnknownTypeValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37C353E63EE8DAA3130D043A0D2EB2F /* UnknownTypeValue.swift */; };
+		F44ECBF1ABB58E1D4064C12D88BA909D /* PrivacyInfo.xcprivacy in Sources */ = {isa = PBXBuildFile; fileRef = E685A93BDD480D9EBB3E40D9D31E964E /* PrivacyInfo.xcprivacy */; };
+		F7A953943973635341397277A7B77E44 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0332EE4AA77385BBB3C3A282AEFDFB /* Router.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		A39FC97A60B4E4EF1C00CDE9EDF2C25D /* PBXContainerItemProxy */ = {
+		9D5732A5EB8BA218D9E058369413E3D9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 11AAFF8883A32F4C9C2E17C1B1AE0614;
 			remoteInfo = FlagsmithClient;
 		};
+		AF57E5ECF5AA5CC6888F2C49B2406A20 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D089F624F760A848617C705876C78058;
+			remoteInfo = "FlagsmithClient-FlagSmith_Privacy";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		010890F60854F25B5CF6D19BAF3B3774 /* FlagsmithAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FlagsmithAnalytics.swift; sourceTree = "<group>"; };
+		01A052BA5448975C6D01FF1003C2FB1D /* FlagsmithClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "FlagsmithClient-Info.plist"; sourceTree = "<group>"; };
+		01BED8F56D2D29829501F35ABA812D07 /* FlagsmithClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FlagsmithClient-prefix.pch"; sourceTree = "<group>"; };
+		02B76A0CC5DD33DC3828D9A6C4BF09F0 /* FlagsmithClient.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = FlagsmithClient.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		02E4DC32B2FC713ED935462DA9F1CBF9 /* Pods-FlagsmithClient_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FlagsmithClient_Example-umbrella.h"; sourceTree = "<group>"; };
-		0CD71DED3359EE67BB9C921E2917DA7A /* Flagsmith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Flagsmith.swift; path = FlagsmithClient/Classes/Flagsmith.swift; sourceTree = "<group>"; };
+		0F1CB950A2B9D94D55201B7B8191BB83 /* Trait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Trait.swift; path = FlagsmithClient/Classes/Trait.swift; sourceTree = "<group>"; };
 		0F66D3EFFD8615AE149DCEEE155C049F /* Pods-FlagsmithClient_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FlagsmithClient_Example-dummy.m"; sourceTree = "<group>"; };
-		0FAC90C1E63439160B035434A1CF25F1 /* FlagsmithClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "FlagsmithClient-Info.plist"; sourceTree = "<group>"; };
-		158A52A6379630867E2111515A492DDE /* TypedValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TypedValue.swift; path = FlagsmithClient/Classes/TypedValue.swift; sourceTree = "<group>"; };
+		193A8DBBF59C95D3ADE40A6CACE88317 /* Flag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Flag.swift; path = FlagsmithClient/Classes/Flag.swift; sourceTree = "<group>"; };
 		250DE57229233B0BAD273A076F108A0E /* Pods-FlagsmithClient_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FlagsmithClient_Example.release.xcconfig"; sourceTree = "<group>"; };
-		2DC8A87D5B1A7F57E12361CE1D5E95B8 /* Flag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Flag.swift; path = FlagsmithClient/Classes/Flag.swift; sourceTree = "<group>"; };
+		33401B963FE6A82269201D80F422B5DC /* Flagsmith+Concurrency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Flagsmith+Concurrency.swift"; path = "FlagsmithClient/Classes/Flagsmith+Concurrency.swift"; sourceTree = "<group>"; };
+		334A531B6E779CB5BBB111407DAB389B /* FlagsmithError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FlagsmithError.swift; path = FlagsmithClient/Classes/FlagsmithError.swift; sourceTree = "<group>"; };
 		368DFAE2AAAB80524EFAFD71A2C92F84 /* Pods-FlagsmithClient_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FlagsmithClient_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		3B040CFA25391975C1615BFB481B68C9 /* Pods-FlagsmithClient_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FlagsmithClient_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		47EFBF8F57718DBF9FE586CBDB6CC0DC /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		4CB810BA1DD243ED447F96C1EC7AD63F /* Trait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Trait.swift; path = FlagsmithClient/Classes/Trait.swift; sourceTree = "<group>"; };
-		591BEAEF977192FC1893BEAC10ABB7F0 /* FlagsmithClient.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = FlagsmithClient.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		5D7B03B15ACDBBDA718D00CF6E18D416 /* Traits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Traits.swift; path = FlagsmithClient/Classes/Traits.swift; sourceTree = "<group>"; };
-		66035645C7F450B9A20A5AA2F1CC43B6 /* Router.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		42419C1B4BE086CC475FA111C3C7F89B /* FlagsmithClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FlagsmithClient-umbrella.h"; sourceTree = "<group>"; };
+		48E24C65212832E53CD320E489F86D56 /* TypedValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TypedValue.swift; path = FlagsmithClient/Classes/TypedValue.swift; sourceTree = "<group>"; };
+		560A2A43C2532F9A60D40C498910BDAD /* Identity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Identity.swift; path = FlagsmithClient/Classes/Identity.swift; sourceTree = "<group>"; };
+		5E0332EE4AA77385BBB3C3A282AEFDFB /* Router.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		5EDBFEFB26106F14D3ACD6A6E8DAF369 /* CachedURLResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CachedURLResponse.swift; sourceTree = "<group>"; };
 		68DDF334F75630BAA85571DF47D87C89 /* FlagsmithClient */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = FlagsmithClient; path = FlagsmithClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6B880F3CB2ABE4DB1E22B3CC5541C2D8 /* FlagsmithClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FlagsmithClient-dummy.m"; sourceTree = "<group>"; };
-		6DEAF76385A937740682012C42A3F628 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		6A93708A2DFB73CD0A47844194EEEF0E /* FlagsmithClient.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FlagsmithClient.debug.xcconfig; sourceTree = "<group>"; };
+		6BD44276DCF6BDE68099A5762C3E3248 /* Traits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Traits.swift; path = FlagsmithClient/Classes/Traits.swift; sourceTree = "<group>"; };
 		73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		7482B233360C108341B85DF6F4F296D2 /* APIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
-		77743E9FB921729A0C34B2CBE7A1F4CD /* FlagsmithAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FlagsmithAnalytics.swift; sourceTree = "<group>"; };
-		7ECFF7C4FBE6AA88F7F7ECDCE6B66EA2 /* FlagsmithClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FlagsmithClient-umbrella.h"; sourceTree = "<group>"; };
-		8078BAE70CEB3897642FFDD030790F4B /* FlagsmithClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FlagsmithClient-prefix.pch"; sourceTree = "<group>"; };
+		740BE3A9082C69EDDCE885472B239E2B /* APIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
+		79F99623D8F2206A889E3FC1BB7E028F /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		7F9C7D04F801E733A55ED8BA67AA84CE /* FlagsmithClient-FlagSmith_Privacy */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "FlagsmithClient-FlagSmith_Privacy"; path = FlagSmith_Privacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		81A815D8A0C28062CD4A8224C6883D5D /* Pods-FlagsmithClient_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-FlagsmithClient_Example.modulemap"; sourceTree = "<group>"; };
-		8236C25B17E89C77288367CCF5B829A9 /* FlagsmithClient.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FlagsmithClient.debug.xcconfig; sourceTree = "<group>"; };
-		919D3C18E297943C015F838AEEAD057F /* Flagsmith+Concurrency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Flagsmith+Concurrency.swift"; path = "FlagsmithClient/Classes/Flagsmith+Concurrency.swift"; sourceTree = "<group>"; };
-		92D88FCDAEE505ABAF4F0C9E59BEBB6A /* CachedURLResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CachedURLResponse.swift; sourceTree = "<group>"; };
-		9B77E851969A4CF4C7F75194BFC80A5B /* Feature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Feature.swift; path = FlagsmithClient/Classes/Feature.swift; sourceTree = "<group>"; };
+		97FECC05C71E791B8A6247E180CDC9BB /* FlagsmithClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = FlagsmithClient.modulemap; sourceTree = "<group>"; };
+		99036F2475C7DD87269B0693A1E508D1 /* Feature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Feature.swift; path = FlagsmithClient/Classes/Feature.swift; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9E877EDD18BF267BC157C6CD6E133BA8 /* FlagsmithClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FlagsmithClient.release.xcconfig; sourceTree = "<group>"; };
 		A7D159AFD71C50F45CAAD458140D8648 /* Pods-FlagsmithClient_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FlagsmithClient_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		B27C6884FC1F031C5CCE03E04DA59B40 /* FlagsmithClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FlagsmithClient.release.xcconfig; sourceTree = "<group>"; };
-		B4164394D814A1BA2FA6A7C7662493C5 /* FlagsmithClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = FlagsmithClient.modulemap; sourceTree = "<group>"; };
+		B3B60DD8AD34844A7BC951D1CADF34DB /* ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist"; sourceTree = "<group>"; };
 		B7528E5D2516E37BD5B3A5DC02010477 /* Pods-FlagsmithClient_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FlagsmithClient_Example-frameworks.sh"; sourceTree = "<group>"; };
 		C1817E8624F31BD483479898AD8A9F9C /* Pods-FlagsmithClient_Example */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-FlagsmithClient_Example"; path = Pods_FlagsmithClient_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CD829895C1256784784DBBFC3020A222 /* FlagsmithError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FlagsmithError.swift; path = FlagsmithClient/Classes/FlagsmithError.swift; sourceTree = "<group>"; };
-		DC513B1FDC4FEFFA6AC514C6DA6E3329 /* UnknownTypeValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UnknownTypeValue.swift; path = FlagsmithClient/Classes/UnknownTypeValue.swift; sourceTree = "<group>"; };
+		C37C353E63EE8DAA3130D043A0D2EB2F /* UnknownTypeValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UnknownTypeValue.swift; path = FlagsmithClient/Classes/UnknownTypeValue.swift; sourceTree = "<group>"; };
+		CC0E8F8144A353EF4972DA8231507159 /* FlagsmithClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FlagsmithClient-dummy.m"; sourceTree = "<group>"; };
+		D30C8727FF378667687B927B401ACFC2 /* Flagsmith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Flagsmith.swift; path = FlagsmithClient/Classes/Flagsmith.swift; sourceTree = "<group>"; };
 		E28010F1C58E656FC37588C8A00FEE38 /* Pods-FlagsmithClient_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FlagsmithClient_Example-Info.plist"; sourceTree = "<group>"; };
-		ED101D3AAE62D955200E49181AC69EF4 /* Identity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Identity.swift; path = FlagsmithClient/Classes/Identity.swift; sourceTree = "<group>"; };
+		E685A93BDD480D9EBB3E40D9D31E964E /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = FlagsmithClient/Classes/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		F68F491C2EB4793199539D7BB50E1A2B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		5978E19B2CF28713F5F5FAE1384AF5B4 /* Frameworks */ = {
+		12C0163E057E9D8C44B9E1980454B186 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				611EFA95BB13886C84B3692AF65E66F8 /* Foundation.framework in Frameworks */,
+				145BDA8A923A4A97F7D1985125F60E67 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,31 +108,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E4C1A32CB959CCA3FE667491F71AA361 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0A0ADE663140E20C1071E72A619CA4E1 /* Products */ = {
+		004E68B560F9B8386F5DB36906B270A5 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				68DDF334F75630BAA85571DF47D87C89 /* FlagsmithClient */,
+				7F9C7D04F801E733A55ED8BA67AA84CE /* FlagsmithClient-FlagSmith_Privacy */,
 				C1817E8624F31BD483479898AD8A9F9C /* Pods-FlagsmithClient_Example */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		27EC56B1B7D07F4EDD85D29A44A2225F /* Support Files */ = {
+		5504E831FC9EDDEE6663BD8753EC1AC0 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				B4164394D814A1BA2FA6A7C7662493C5 /* FlagsmithClient.modulemap */,
-				6B880F3CB2ABE4DB1E22B3CC5541C2D8 /* FlagsmithClient-dummy.m */,
-				0FAC90C1E63439160B035434A1CF25F1 /* FlagsmithClient-Info.plist */,
-				8078BAE70CEB3897642FFDD030790F4B /* FlagsmithClient-prefix.pch */,
-				7ECFF7C4FBE6AA88F7F7ECDCE6B66EA2 /* FlagsmithClient-umbrella.h */,
-				8236C25B17E89C77288367CCF5B829A9 /* FlagsmithClient.debug.xcconfig */,
-				B27C6884FC1F031C5CCE03E04DA59B40 /* FlagsmithClient.release.xcconfig */,
+				740BE3A9082C69EDDCE885472B239E2B /* APIManager.swift */,
+				5EDBFEFB26106F14D3ACD6A6E8DAF369 /* CachedURLResponse.swift */,
+				010890F60854F25B5CF6D19BAF3B3774 /* FlagsmithAnalytics.swift */,
+				5E0332EE4AA77385BBB3C3A282AEFDFB /* Router.swift */,
 			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/FlagsmithClient";
+			name = Internal;
+			path = FlagsmithClient/Classes/Internal;
 			sourceTree = "<group>";
 		};
 		578452D2E740E91742655AC8F1636D1F /* iOS */ = {
@@ -148,33 +165,22 @@
 			path = "Target Support Files/Pods-FlagsmithClient_Example";
 			sourceTree = "<group>";
 		};
-		743FF37545C268C8B74711C93A390E32 /* FlagsmithClient */ = {
+		83DF8963328A9E0494B7C83B809AF479 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				9B77E851969A4CF4C7F75194BFC80A5B /* Feature.swift */,
-				2DC8A87D5B1A7F57E12361CE1D5E95B8 /* Flag.swift */,
-				0CD71DED3359EE67BB9C921E2917DA7A /* Flagsmith.swift */,
-				919D3C18E297943C015F838AEEAD057F /* Flagsmith+Concurrency.swift */,
-				CD829895C1256784784DBBFC3020A222 /* FlagsmithError.swift */,
-				ED101D3AAE62D955200E49181AC69EF4 /* Identity.swift */,
-				4CB810BA1DD243ED447F96C1EC7AD63F /* Trait.swift */,
-				5D7B03B15ACDBBDA718D00CF6E18D416 /* Traits.swift */,
-				158A52A6379630867E2111515A492DDE /* TypedValue.swift */,
-				DC513B1FDC4FEFFA6AC514C6DA6E3329 /* UnknownTypeValue.swift */,
-				CE24075F0AA68AF97EBFE976DF0970CD /* Internal */,
-				E3A6070C6F3B520898B030B46D84A64C /* Pod */,
-				27EC56B1B7D07F4EDD85D29A44A2225F /* Support Files */,
-			);
-			name = FlagsmithClient;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		8771110EE67E622B18478ADE12D92BE5 /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				743FF37545C268C8B74711C93A390E32 /* FlagsmithClient */,
+				EB5B366C3102D180EE97EBB112A2C98A /* FlagsmithClient */,
 			);
 			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		A880B46BBE672F8B5031ACED24CDDC51 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				02B76A0CC5DD33DC3828D9A6C4BF09F0 /* FlagsmithClient.podspec */,
+				79F99623D8F2206A889E3FC1BB7E028F /* LICENSE */,
+				F68F491C2EB4793199539D7BB50E1A2B /* README.md */,
+			);
+			name = Pod;
 			sourceTree = "<group>";
 		};
 		BA8A3B9AA623A3EC5D887B56C04C7D73 /* Targets Support Files */ = {
@@ -185,25 +191,13 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		CE24075F0AA68AF97EBFE976DF0970CD /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				7482B233360C108341B85DF6F4F296D2 /* APIManager.swift */,
-				92D88FCDAEE505ABAF4F0C9E59BEBB6A /* CachedURLResponse.swift */,
-				77743E9FB921729A0C34B2CBE7A1F4CD /* FlagsmithAnalytics.swift */,
-				66035645C7F450B9A20A5AA2F1CC43B6 /* Router.swift */,
-			);
-			name = Internal;
-			path = FlagsmithClient/Classes/Internal;
-			sourceTree = "<group>";
-		};
 		CF1408CF629C7361332E53B88F7BD30C = {
 			isa = PBXGroup;
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
-				8771110EE67E622B18478ADE12D92BE5 /* Development Pods */,
+				83DF8963328A9E0494B7C83B809AF479 /* Development Pods */,
 				D210D550F4EA176C3123ED886F8F87F5 /* Frameworks */,
-				0A0ADE663140E20C1071E72A619CA4E1 /* Products */,
+				004E68B560F9B8386F5DB36906B270A5 /* Products */,
 				BA8A3B9AA623A3EC5D887B56C04C7D73 /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
@@ -216,14 +210,42 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		E3A6070C6F3B520898B030B46D84A64C /* Pod */ = {
+		DD874B272A864A7F34C517E2F9F6438B /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				591BEAEF977192FC1893BEAC10ABB7F0 /* FlagsmithClient.podspec */,
-				47EFBF8F57718DBF9FE586CBDB6CC0DC /* LICENSE */,
-				6DEAF76385A937740682012C42A3F628 /* README.md */,
+				97FECC05C71E791B8A6247E180CDC9BB /* FlagsmithClient.modulemap */,
+				CC0E8F8144A353EF4972DA8231507159 /* FlagsmithClient-dummy.m */,
+				01A052BA5448975C6D01FF1003C2FB1D /* FlagsmithClient-Info.plist */,
+				01BED8F56D2D29829501F35ABA812D07 /* FlagsmithClient-prefix.pch */,
+				42419C1B4BE086CC475FA111C3C7F89B /* FlagsmithClient-umbrella.h */,
+				6A93708A2DFB73CD0A47844194EEEF0E /* FlagsmithClient.debug.xcconfig */,
+				9E877EDD18BF267BC157C6CD6E133BA8 /* FlagsmithClient.release.xcconfig */,
+				B3B60DD8AD34844A7BC951D1CADF34DB /* ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist */,
 			);
-			name = Pod;
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/FlagsmithClient";
+			sourceTree = "<group>";
+		};
+		EB5B366C3102D180EE97EBB112A2C98A /* FlagsmithClient */ = {
+			isa = PBXGroup;
+			children = (
+				99036F2475C7DD87269B0693A1E508D1 /* Feature.swift */,
+				193A8DBBF59C95D3ADE40A6CACE88317 /* Flag.swift */,
+				D30C8727FF378667687B927B401ACFC2 /* Flagsmith.swift */,
+				33401B963FE6A82269201D80F422B5DC /* Flagsmith+Concurrency.swift */,
+				334A531B6E779CB5BBB111407DAB389B /* FlagsmithError.swift */,
+				560A2A43C2532F9A60D40C498910BDAD /* Identity.swift */,
+				E685A93BDD480D9EBB3E40D9D31E964E /* PrivacyInfo.xcprivacy */,
+				0F1CB950A2B9D94D55201B7B8191BB83 /* Trait.swift */,
+				6BD44276DCF6BDE68099A5762C3E3248 /* Traits.swift */,
+				48E24C65212832E53CD320E489F86D56 /* TypedValue.swift */,
+				C37C353E63EE8DAA3130D043A0D2EB2F /* UnknownTypeValue.swift */,
+				5504E831FC9EDDEE6663BD8753EC1AC0 /* Internal */,
+				A880B46BBE672F8B5031ACED24CDDC51 /* Pod */,
+				DD874B272A864A7F34C517E2F9F6438B /* Support Files */,
+			);
+			name = FlagsmithClient;
+			path = ../..;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -237,11 +259,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		98DBC9670D86FAE13772BFFB393D0029 /* Headers */ = {
+		B0B82A0BFE945677F027568CF40F606B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7296A208906AA3BC74014294652982CA /* FlagsmithClient-umbrella.h in Headers */,
+				E4162B22739D5F7D0728E35C4B806BB5 /* FlagsmithClient-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -250,16 +272,17 @@
 /* Begin PBXNativeTarget section */
 		11AAFF8883A32F4C9C2E17C1B1AE0614 /* FlagsmithClient */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CE8A22033473608C91867F497BC5A2CD /* Build configuration list for PBXNativeTarget "FlagsmithClient" */;
+			buildConfigurationList = ABD7FC62C2B9ACFD025EB9237D4ADBFE /* Build configuration list for PBXNativeTarget "FlagsmithClient" */;
 			buildPhases = (
-				98DBC9670D86FAE13772BFFB393D0029 /* Headers */,
-				29A741F17A46BDD22AB2213A04FDE505 /* Sources */,
-				5978E19B2CF28713F5F5FAE1384AF5B4 /* Frameworks */,
-				D0516BC3E528E09D1C43539B158EED35 /* Resources */,
+				B0B82A0BFE945677F027568CF40F606B /* Headers */,
+				D9978955D1F7D97BA5C53A6F2B02A6AF /* Sources */,
+				12C0163E057E9D8C44B9E1980454B186 /* Frameworks */,
+				4B831344AB43BCEBB55AC7A0D1BD1D0A /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				AB585B4EA3B1A537EA9707B6BF2CECDC /* PBXTargetDependency */,
 			);
 			name = FlagsmithClient;
 			productName = FlagsmithClient;
@@ -278,12 +301,29 @@
 			buildRules = (
 			);
 			dependencies = (
-				6A2A4CDB21FA43CDB219D90367EBBD10 /* PBXTargetDependency */,
+				54A900312AEF2FB8D47E285B59D9AF7F /* PBXTargetDependency */,
 			);
 			name = "Pods-FlagsmithClient_Example";
 			productName = Pods_FlagsmithClient_Example;
 			productReference = C1817E8624F31BD483479898AD8A9F9C /* Pods-FlagsmithClient_Example */;
 			productType = "com.apple.product-type.framework";
+		};
+		D089F624F760A848617C705876C78058 /* FlagsmithClient-FlagSmith_Privacy */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D9D115EFB53F932E6EDDE9FCD80E521A /* Build configuration list for PBXNativeTarget "FlagsmithClient-FlagSmith_Privacy" */;
+			buildPhases = (
+				A4E89541AF518F781354C01097A6F67B /* Sources */,
+				E4C1A32CB959CCA3FE667491F71AA361 /* Frameworks */,
+				EE871D842E8E68C7D392182D72D98F65 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FlagsmithClient-FlagSmith_Privacy";
+			productName = FlagSmith_Privacy;
+			productReference = 7F9C7D04F801E733A55ED8BA67AA84CE /* FlagsmithClient-FlagSmith_Privacy */;
+			productType = "com.apple.product-type.bundle";
 		};
 /* End PBXNativeTarget section */
 
@@ -303,17 +343,26 @@
 				en,
 			);
 			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
-			productRefGroup = 0A0ADE663140E20C1071E72A619CA4E1 /* Products */;
+			productRefGroup = 004E68B560F9B8386F5DB36906B270A5 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				11AAFF8883A32F4C9C2E17C1B1AE0614 /* FlagsmithClient */,
+				D089F624F760A848617C705876C78058 /* FlagsmithClient-FlagSmith_Privacy */,
 				770799B5DCFAB0B1BCF1BD365E2C1BC5 /* Pods-FlagsmithClient_Example */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4B831344AB43BCEBB55AC7A0D1BD1D0A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				36A99CA483CA4242032567EFEC9024E9 /* FlagsmithClient-FlagSmith_Privacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7DD4986852439651139309DE21E874D5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -321,7 +370,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D0516BC3E528E09D1C43539B158EED35 /* Resources */ = {
+		EE871D842E8E68C7D392182D72D98F65 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -331,28 +380,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		29A741F17A46BDD22AB2213A04FDE505 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				361AD17B75FDA9970FF500DEE9B88729 /* APIManager.swift in Sources */,
-				6EABC9E673A27FAC4180F2F08C4F2B3D /* CachedURLResponse.swift in Sources */,
-				CFFE0F58344636A5789C357F2BE50820 /* Feature.swift in Sources */,
-				F0F13B1D5F547C03C257DF46C49594E4 /* Flag.swift in Sources */,
-				28E2C1F327F2FEFC3D6193D0E775DD16 /* Flagsmith.swift in Sources */,
-				82EA3819E558968027E9A21E8E20A4A7 /* Flagsmith+Concurrency.swift in Sources */,
-				011196679F1DBAD78B3284BB60F1CC7E /* FlagsmithAnalytics.swift in Sources */,
-				B9ECC98F1865D64AA4B986208D0938C1 /* FlagsmithClient-dummy.m in Sources */,
-				CFC4FDB2F9D6E43C28FE902C6131C027 /* FlagsmithError.swift in Sources */,
-				A3EAECF66E99CCF1D3251DB251AE6F9D /* Identity.swift in Sources */,
-				95A960387ADF0D89DD60C4E6F563455F /* Router.swift in Sources */,
-				97DE10D6905CEF731DD15EB738B843DD /* Trait.swift in Sources */,
-				90AE5624A1F9C4DAA5ED6ED01FB6AA98 /* Traits.swift in Sources */,
-				A9DAAC7965A5F9D409F7335FC223BEE6 /* TypedValue.swift in Sources */,
-				78FC3BC1E0FADEB53A278A0A4C6DA6E8 /* UnknownTypeValue.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		660F00CEBC7EEE195DEDCC6CBB923CEA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -361,80 +388,85 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A4E89541AF518F781354C01097A6F67B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D9978955D1F7D97BA5C53A6F2B02A6AF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1848829C29C5631D664CC0742A63EC33 /* APIManager.swift in Sources */,
+				4FB62CFD8230DFD531423AC407FFBF12 /* CachedURLResponse.swift in Sources */,
+				41403B5BE8BE6F8EF3DD6D51EB8A05CD /* Feature.swift in Sources */,
+				0083552669FD822D4A203F429BEF6F8C /* Flag.swift in Sources */,
+				8C16371FF3BD75AA8903F1364B84C902 /* Flagsmith.swift in Sources */,
+				976897ECFF1B33FC921C0C50A0F2A156 /* Flagsmith+Concurrency.swift in Sources */,
+				C462C452A86C94C3B33BA403FD5102C3 /* FlagsmithAnalytics.swift in Sources */,
+				D804DCDEA2D5AC6CE809EC8D972B3A80 /* FlagsmithClient-dummy.m in Sources */,
+				7A6E9ACE7C0730D83DC68A952B450CBF /* FlagsmithError.swift in Sources */,
+				4BC792BD210D6770E120952EC1A6149F /* Identity.swift in Sources */,
+				F44ECBF1ABB58E1D4064C12D88BA909D /* PrivacyInfo.xcprivacy in Sources */,
+				F7A953943973635341397277A7B77E44 /* Router.swift in Sources */,
+				391C8F320DDD9EAB5996574CB69D38A6 /* Trait.swift in Sources */,
+				9A443C01EC676628F306F7E210F63CBC /* Traits.swift in Sources */,
+				200C93079A049CC69CF5844427F65359 /* TypedValue.swift in Sources */,
+				F440E618661D6B6DB91C40AA067EE9AE /* UnknownTypeValue.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		6A2A4CDB21FA43CDB219D90367EBBD10 /* PBXTargetDependency */ = {
+		54A900312AEF2FB8D47E285B59D9AF7F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = FlagsmithClient;
 			target = 11AAFF8883A32F4C9C2E17C1B1AE0614 /* FlagsmithClient */;
-			targetProxy = A39FC97A60B4E4EF1C00CDE9EDF2C25D /* PBXContainerItemProxy */;
+			targetProxy = 9D5732A5EB8BA218D9E058369413E3D9 /* PBXContainerItemProxy */;
+		};
+		AB585B4EA3B1A537EA9707B6BF2CECDC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "FlagsmithClient-FlagSmith_Privacy";
+			target = D089F624F760A848617C705876C78058 /* FlagsmithClient-FlagSmith_Privacy */;
+			targetProxy = AF57E5ECF5AA5CC6888F2C49B2406A20 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		0B1CDA5D382F4F3C96E9AE205B213EE1 /* Debug */ = {
+		049EEB1E25BB61D149D6D294514FA82A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8236C25B17E89C77288367CCF5B829A9 /* FlagsmithClient.debug.xcconfig */;
+			baseConfigurationReference = 6A93708A2DFB73CD0A47844194EEEF0E /* FlagsmithClient.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/FlagsmithClient/FlagsmithClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/FlagsmithClient/FlagsmithClient-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/FlagsmithClient";
+				IBSC_MODULE = FlagsmithClient;
+				INFOPLIST_FILE = "Target Support Files/FlagsmithClient/ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FlagsmithClient/FlagsmithClient.modulemap";
-				PRODUCT_MODULE_NAME = FlagsmithClient;
-				PRODUCT_NAME = FlagsmithClient;
+				PRODUCT_NAME = FlagSmith_Privacy;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
+				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
 		};
-		12BB8FAF3E0B6864216E35B141237E9A /* Release */ = {
+		2769E86984A0005886AC6DA3DEEF5E58 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B27C6884FC1F031C5CCE03E04DA59B40 /* FlagsmithClient.release.xcconfig */;
+			baseConfigurationReference = 9E877EDD18BF267BC157C6CD6E133BA8 /* FlagsmithClient.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/FlagsmithClient/FlagsmithClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/FlagsmithClient/FlagsmithClient-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/FlagsmithClient";
+				IBSC_MODULE = FlagsmithClient;
+				INFOPLIST_FILE = "Target Support Files/FlagsmithClient/ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FlagsmithClient/FlagsmithClient.modulemap";
-				PRODUCT_MODULE_NAME = FlagsmithClient;
-				PRODUCT_NAME = FlagsmithClient;
+				PRODUCT_NAME = FlagSmith_Privacy;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
+				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;
 		};
@@ -501,6 +533,71 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		58E625716FA7C3CCECC76379D437F52F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9E877EDD18BF267BC157C6CD6E133BA8 /* FlagsmithClient.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/FlagsmithClient/FlagsmithClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/FlagsmithClient/FlagsmithClient-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FlagsmithClient/FlagsmithClient.modulemap";
+				PRODUCT_MODULE_NAME = FlagsmithClient;
+				PRODUCT_NAME = FlagsmithClient;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.6;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		599DF1132B45CDE985F883321D83D83F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6A93708A2DFB73CD0A47844194EEEF0E /* FlagsmithClient.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/FlagsmithClient/FlagsmithClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/FlagsmithClient/FlagsmithClient-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FlagsmithClient/FlagsmithClient.modulemap";
+				PRODUCT_MODULE_NAME = FlagsmithClient;
+				PRODUCT_NAME = FlagsmithClient;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.6;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
@@ -656,11 +753,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CE8A22033473608C91867F497BC5A2CD /* Build configuration list for PBXNativeTarget "FlagsmithClient" */ = {
+		ABD7FC62C2B9ACFD025EB9237D4ADBFE /* Build configuration list for PBXNativeTarget "FlagsmithClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0B1CDA5D382F4F3C96E9AE205B213EE1 /* Debug */,
-				12BB8FAF3E0B6864216E35B141237E9A /* Release */,
+				599DF1132B45CDE985F883321D83D83F /* Debug */,
+				58E625716FA7C3CCECC76379D437F52F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D9D115EFB53F932E6EDDE9FCD80E521A /* Build configuration list for PBXNativeTarget "FlagsmithClient-FlagSmith_Privacy" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				049EEB1E25BB61D149D6D294514FA82A /* Debug */,
+				2769E86984A0005886AC6DA3DEEF5E58 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Target Support Files/FlagsmithClient/FlagsmithClient-Info.plist
+++ b/Example/Pods/Target Support Files/FlagsmithClient/FlagsmithClient-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.6.0</string>
+  <string>3.5.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/FlagsmithClient/ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist
+++ b/Example/Pods/Target Support Files/FlagsmithClient/ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>${PODS_DEVELOPMENT_LANGUAGE}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>3.6.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/Example/Pods/Target Support Files/FlagsmithClient/ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist
+++ b/Example/Pods/Target Support Files/FlagsmithClient/ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.6.0</string>
+  <string>3.5.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/FlagsmithClient.podspec
+++ b/FlagsmithClient.podspec
@@ -15,6 +15,9 @@ Pod::Spec.new do |s|
   s.author           = { 'Kyle Johnson' => 'Kyle.johnson@flagsmith.com' }
   s.source           = { :git => 'https://github.com/Flagsmith/flagsmith-ios-client.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/getflagsmith'
+  s.resource_bundles = {
+    'FlagSmith_Privacy' => ['Classes/PrivacyInfo.xcprivacy'],
+  }
 
   s.ios.deployment_target = '12.0'
 

--- a/FlagsmithClient/Classes/PrivacyInfo.xcprivacy
+++ b/FlagsmithClient/Classes/PrivacyInfo.xcprivacy
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyTrackingDomains</key>
+	<array>
+		<string>edge.api.flagsmith.com</string>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<true/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/FlagsmithClient/Classes/PrivacyInfo.xcprivacy
+++ b/FlagsmithClient/Classes/PrivacyInfo.xcprivacy
@@ -13,7 +13,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 	</array>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 import PackageDescription
 
@@ -11,10 +11,17 @@ let package = Package(
         .target(
             name: "FlagsmithClient",
             dependencies: [],
-            path: "FlagsmithClient/Classes"),
+            path: "FlagsmithClient/Classes",
+            resources: [
+                .copy("PrivacyInfo.xcprivacy"),
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+                .enableUpcomingFeature("ExistentialAny"), // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
+            ]),
         .testTarget(
             name: "FlagsmitClientTests",
             dependencies: ["FlagsmithClient"],
-            path: "FlagsmithClient/Tests"),
+            path: "FlagsmithClient/Tests")
     ]
 )


### PR DESCRIPTION
## Description

Due to upcoming https://developer.apple.com/support/third-party-SDK-requirements/ we've updated the SDK to include a Privacy Manifest.

The format and purpose of these is described here: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files

The crux of what I've gone for on here is:

UserDefaults: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401

This is needed to store persistent state info for the SDK. At the moment this is just used to store analytics events in the case they can't be sent immediately. This could possibly be removed in the future if you're (a) not that fussed and we (b) post analytics when the app goes to the background to avoid data loss.

Other Diagnostic Data:

https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests#4144131

I've tested this with the unit tests and also creating local packages with Swift Package Manager and Cocoapods to see if the Privacy Manifest is included, which it does appear to be. When running the new SDK in the example app I didn't see any additional privacy dialogs appear.

I've also checked my changes against other popular iOS SDKs and can confirm they're consistent.

Manifest files are typically checked by Apple automatically when submitting to the App Store, so that's going to be the real test for this one.



## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
