### PR TITLE
Feature/remove tracking domain & tracking boolean

### DIFF
--- a/Example/FlagsmithClient.xcodeproj/project.pbxproj
+++ b/Example/FlagsmithClient.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = RYCT86V4LM;
 						LastSwiftMigration = 1020;
 					};
 				};
@@ -292,7 +293,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -342,7 +343,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -355,6 +356,7 @@
 			baseConfigurationReference = 9DFD4B33E10902546A38D90F /* Pods-FlagsmithClient_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = RYCT86V4LM;
 				INFOPLIST_FILE = FlagsmithClient/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
@@ -369,6 +371,7 @@
 			baseConfigurationReference = 5357A0EF6DA00FB7B1E84F8C /* Pods-FlagsmithClient_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = RYCT86V4LM;
 				INFOPLIST_FILE = FlagsmithClient/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;

--- a/Example/FlagsmithClient/Info.plist
+++ b/Example/FlagsmithClient/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Just for Flagsmith Analytics</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Example/FlagsmithClient/ViewController.swift
+++ b/Example/FlagsmithClient/ViewController.swift
@@ -8,7 +8,33 @@
 
 import UIKit
 import FlagsmithClient
+import AppTrackingTransparency
+import AdSupport
 
 class ViewController: UIViewController {
+  
+  override func viewDidLoad() {
+      super.viewDidLoad()
+      // Request user authorization for tracking
+      ATTrackingManager.requestTrackingAuthorization { status in
+          switch status {
+          case .authorized:
+              // Tracking authorization granted
+              print("Tracking authorization granted")
+          case .denied:
+              // Tracking authorization denied
+              print("Tracking authorization denied")
+          case .restricted:
+              // Tracking restricted
+              print("Tracking restricted")
+          case .notDetermined:
+              // Tracking authorization not determined
+              print("Tracking authorization not determined")
+          @unknown default:
+              // Handle other cases
+              print("Unknown tracking authorization status")
+          }
+      }
+  }
 
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FlagsmithClient (3.5.0)
+  - FlagsmithClient (3.6.0)
 
 DEPENDENCIES:
   - FlagsmithClient (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FlagsmithClient: 505f315402ddf4482c3477dd4a6124ab8e63361e
+  FlagsmithClient: 101151384696085c085d06b1c202946827e058d6
 
 PODFILE CHECKSUM: 9fc876dee0cf031cae843156b0740a94b4994d8c
 

--- a/Example/Pods/Local Podspecs/FlagsmithClient.podspec.json
+++ b/Example/Pods/Local Podspecs/FlagsmithClient.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "FlagsmithClient",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "summary": "iOS Client written in Swift for Flagsmith. Ship features with confidence using feature flags and remote config.",
   "homepage": "https://github.com/Flagsmith/flagsmith-ios-client",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/Flagsmith/flagsmith-ios-client.git",
-    "tag": "3.5.0"
+    "tag": "3.6.0"
   },
   "social_media_url": "https://twitter.com/getflagsmith",
   "resource_bundles": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FlagsmithClient (3.5.0)
+  - FlagsmithClient (3.6.0)
 
 DEPENDENCIES:
   - FlagsmithClient (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FlagsmithClient: 505f315402ddf4482c3477dd4a6124ab8e63361e
+  FlagsmithClient: 101151384696085c085d06b1c202946827e058d6
 
 PODFILE CHECKSUM: 9fc876dee0cf031cae843156b0740a94b4994d8c
 

--- a/Example/Pods/Target Support Files/FlagsmithClient/FlagsmithClient-Info.plist
+++ b/Example/Pods/Target Support Files/FlagsmithClient/FlagsmithClient-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.5.0</string>
+  <string>3.6.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/FlagsmithClient/ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist
+++ b/Example/Pods/Target Support Files/FlagsmithClient/ResourceBundle-FlagSmith_Privacy-FlagsmithClient-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.5.0</string>
+  <string>3.6.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/FlagsmithClient/Classes/PrivacyInfo.xcprivacy
+++ b/FlagsmithClient/Classes/PrivacyInfo.xcprivacy
@@ -17,12 +17,8 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>edge.api.flagsmith.com</string>
-	</array>
 	<key>NSPrivacyTracking</key>
-	<true/>
+	<false/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Description

Remove our domain and tracking reference from the privacy manifest to hopefully fix https://github.com/Flagsmith/flagsmith-ios-client/issues/57

I've tried to reproduce the customer issue with the test app but unfortunately I've not been able to. My research however suggests that this fix should cover us, and is in-line with the privacy manifests of most of our contemporaries.

Removing the domain should stop it from being blocked when the user declines tracking.

The definition of 'tracking' WRT Apple is in here - https://developer.apple.com/app-store/user-privacy-and-data-use/

With the relevant Apple documentation here - https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
