### PR TITLE
Update Flagsmith_privacy location and name

### DIFF
--- a/FlagsmithClient.podspec
+++ b/FlagsmithClient.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/Flagsmith/flagsmith-ios-client.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/getflagsmith'
   s.resource_bundles = {
-    'FlagSmith_Privacy' => ['Classes/PrivacyInfo.xcprivacy'],
+    'Flagsmith_Privacy' => ['FlagsmithClient/Classes/PrivacyInfo.xcprivacy'],
   }
 
   s.ios.deployment_target = '12.0'


### PR DESCRIPTION
This PR should fix an issue running `pod spec lint` as part of the build process. Previously, I was getting: 

```
ERROR | [iOS] file patterns: The `resource_bundles` pattern for `FlagSmith_Privacy` did not match any file.
```

Note that this PR also corrects the terminology from 'FlagSmith_privacy' (triggered by the incorrect capitalisation of the 's' in Flagsmith). 