### PR TITLE
Bump version 3.6.2

### DIFF
--- a/FlagsmithClient.podspec
+++ b/FlagsmithClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FlagsmithClient'
-  s.version          = '3.6.1'
+  s.version          = '3.6.2'
   s.summary          = 'iOS Client written in Swift for Flagsmith. Ship features with confidence using feature flags and remote config.'
   s.homepage         = 'https://github.com/Flagsmith/flagsmith-ios-client'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
Due to uncertainty about whether the version in Swift Package Manager is up to date after I had to delete and recreate the tag for 3.6.1, I am bumping the version to 3.6.2 to re-trigger the package manager to update itself. 