### PR TITLE
feat: Support transient identities and traits

### DIFF
--- a/Example/FlagsmithClient/Base.lproj/LaunchScreen.xib
+++ b/Example/FlagsmithClient/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -11,14 +12,14 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2019 SolidStateGroup. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2024 Flagsmith. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="440" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" systemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FlagsmithClient" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
-                    <rect key="frame" x="20" y="140" width="440" height="43"/>
+                    <rect key="frame" x="20" y="139.66666666666666" width="440" height="43"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
                     <color key="textColor" systemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>

--- a/FlagsmithClient/Classes/Flagsmith.swift
+++ b/FlagsmithClient/Classes/Flagsmith.swift
@@ -90,7 +90,9 @@ public final class Flagsmith: @unchecked Sendable {
     {
         if let identity = identity {
             if let traits = traits {
-                apiManager.request(.postTraits(identity: identity, traits: traits, transient: transient)) { (result: Result<Traits, Error>) in
+                apiManager.request(
+                    .postTraits(identity: identity, traits: traits, transient: transient)
+                ) { (result: Result<Traits, Error>) in
                     switch result {
                     case let .success(result):
                         completion(.success(result.flags))

--- a/FlagsmithClient/Classes/Flagsmith.swift
+++ b/FlagsmithClient/Classes/Flagsmith.swift
@@ -81,14 +81,16 @@ public final class Flagsmith: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - identity: ID of the user (optional)
+    ///   - transient: If `true`, identity is not persisted
     ///   - completion: Closure with Result which contains array of Flag objects in case of success or Error in case of failure
     public func getFeatureFlags(forIdentity identity: String? = nil,
                                 traits: [Trait]? = nil,
+                                transient: Bool = false,
                                 completion: @Sendable @escaping (Result<[Flag], any Error>) -> Void)
     {
         if let identity = identity {
             if let traits = traits {
-                apiManager.request(.postTraits(identity: identity, traits: traits)) { (result: Result<Traits, Error>) in
+                apiManager.request(.postTraits(identity: identity, traits: traits, transient: transient)) { (result: Result<Traits, Error>) in
                     switch result {
                     case let .success(result):
                         completion(.success(result.flags))
@@ -97,7 +99,7 @@ public final class Flagsmith: @unchecked Sendable {
                     }
                 }
             } else {
-                getIdentity(identity) { result in
+                getIdentity(identity, transient: transient) { result in
                     switch result {
                     case let .success(thisIdentity):
                         completion(.success(thisIdentity.flags))
@@ -289,8 +291,10 @@ public final class Flagsmith: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - identity: ID of the user
+    ///   - transient: If `true`, identity is not persisted
     ///   - completion: Closure with Result which contains Identity in case of success or Error in case of failure
     public func getIdentity(_ identity: String,
+                            transient: Bool = false,
                             completion: @Sendable @escaping (Result<Identity, any Error>) -> Void)
     {
         apiManager.request(.getIdentity(identity: identity)) { (result: Result<Identity, Error>) in

--- a/FlagsmithClient/Classes/Identity.swift
+++ b/FlagsmithClient/Classes/Identity.swift
@@ -8,14 +8,17 @@
 import Foundation
 
 /**
- An Identity represents a user stored on the server.
+ An `Identity` represents a set of user data used for flag evaluation.
+ An `Identity` with `transient` set to `true` is not stored in Flagsmith backend.
  */
 public struct Identity: Decodable, Sendable {
     enum CodingKeys: String, CodingKey {
         case flags
         case traits
+        case transient
     }
 
     public let flags: [Flag]
     public let traits: [Trait]
+    public let transient: Bool
 }

--- a/FlagsmithClient/Classes/Internal/Router.swift
+++ b/FlagsmithClient/Classes/Internal/Router.swift
@@ -17,9 +17,9 @@ enum Router: Sendable {
     }
 
     case getFlags
-    case getIdentity(identity: String)
+    case getIdentity(identity: String, transient: Bool = false)
     case postTrait(trait: Trait, identity: String)
-    case postTraits(identity: String, traits: [Trait])
+    case postTraits(identity: String, traits: [Trait], transient: Bool = false)
     case postAnalytics(events: [String: Int])
 
     private var method: HTTPMethod {
@@ -46,8 +46,12 @@ enum Router: Sendable {
 
     private var parameters: [URLQueryItem]? {
         switch self {
-        case let .getIdentity(identity), let .postTraits(identity, _):
-            return [URLQueryItem(name: "identifier", value: identity)]
+        case let .getIdentity(identity, transient):
+            var queryItems = [URLQueryItem(name: "identifier", value: identity)]
+            if transient {
+                queryItems.append(URLQueryItem(name: "transient", value: "true"))
+            }
+            return queryItems
         default:
             return nil
         }
@@ -60,8 +64,8 @@ enum Router: Sendable {
         case let .postTrait(trait, identifier):
             let traitWithIdentity = Trait(trait: trait, identifier: identifier)
             return try encoder.encode(traitWithIdentity)
-        case let .postTraits(identifier, traits):
-            let traitsWithIdentity = Traits(traits: traits, identifier: identifier)
+        case let .postTraits(identifier, traits, transient):
+            let traitsWithIdentity = Traits(traits: traits, identifier: identifier, transient: transient)
             return try encoder.encode(traitsWithIdentity)
         case let .postAnalytics(events):
             return try encoder.encode(events)

--- a/FlagsmithClient/Classes/Traits.swift
+++ b/FlagsmithClient/Classes/Traits.swift
@@ -14,10 +14,19 @@ public struct Traits: Codable, Sendable {
     public let traits: [Trait]
     public let identifier: String?
     public let flags: [Flag]
+    public let transient: Bool
     
-    init(traits: [Trait], identifier: String?, flags: [Flag] = []) {
+    init(traits: [Trait], identifier: String?, flags: [Flag] = [], transient: Bool? = false) {
         self.traits = traits
         self.identifier = identifier
         self.flags = flags
+        self.transient = transient ?? false
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(traits, forKey: .traits)
+        try container.encode(identifier, forKey: .identifier)
+        try container.encode(transient, forKey: .transient)
     }
 }

--- a/FlagsmithClient/Classes/Traits.swift
+++ b/FlagsmithClient/Classes/Traits.swift
@@ -16,11 +16,11 @@ public struct Traits: Codable, Sendable {
     public let flags: [Flag]
     public let transient: Bool
     
-    init(traits: [Trait], identifier: String?, flags: [Flag] = [], transient: Bool? = false) {
+    init(traits: [Trait], identifier: String?, flags: [Flag] = [], transient: Bool = false) {
         self.traits = traits
         self.identifier = identifier
         self.flags = flags
-        self.transient = transient ?? false
+        self.transient = transient
     }
 
     public func encode(to encoder: any Encoder) throws {


### PR DESCRIPTION
Closes #63.

- Add optional `transient` argument to  `getFeatureFlags`
- Add optional `transient` attribute to `Trait` struct
- Remove redundant `identifier` query parameter from `POST /api/v1/identities` call
- Remove unneeded `flags` JSON body key from `POST /api/v1/identities` call
- Update copyright in example app