### PR TITLE
fix: Swift.DecodingError.keyNotFound when decoding Traits

### DIFF
--- a/FlagsmithClient/Classes/Identity.swift
+++ b/FlagsmithClient/Classes/Identity.swift
@@ -20,5 +20,5 @@ public struct Identity: Decodable, Sendable {
 
     public let flags: [Flag]
     public let traits: [Trait]
-    public let transient: Bool
+    public let transient: Bool?
 }

--- a/FlagsmithClient/Classes/Trait.swift
+++ b/FlagsmithClient/Classes/Trait.swift
@@ -26,7 +26,7 @@ public struct Trait: Codable, Sendable {
     /// - note: In the future, this can be renamed back to 'value' as major/feature-breaking
     ///         updates are released.
     public var typedValue: TypedValue
-    public let transient: Bool
+    public let transient: Bool?
     /// The identity of the `Trait` when creating.
     internal let identifier: String?
     

--- a/FlagsmithClient/Classes/Traits.swift
+++ b/FlagsmithClient/Classes/Traits.swift
@@ -14,7 +14,7 @@ public struct Traits: Codable, Sendable {
     public let traits: [Trait]
     public let identifier: String?
     public let flags: [Flag]
-    public let transient: Bool
+    public let transient: Bool?
     
     init(traits: [Trait], identifier: String?, flags: [Flag] = [], transient: Bool = false) {
         self.traits = traits
@@ -30,3 +30,4 @@ public struct Traits: Codable, Sendable {
         try container.encode(transient, forKey: .transient)
     }
 }
+


### PR DESCRIPTION
Closes #70.