### PR TITLE
ci: add workflow to publish to CocoaPods

### DIFF
--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Install Cocoapods
         run: gem install cocoapods
 
-      # - name: Deploy to Cocoapods
-      #   run: |
-      #     set -eo pipefail
-      #     pod lib lint --allow-warnings
-      #     pod trunk push --allow-warnings
-      #   env:
-      #     COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      - name: Deploy to Cocoapods
+        run: |
+          set -eo pipefail
+          pod lib lint --allow-warnings
+          pod trunk push --allow-warnings
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -2,6 +2,8 @@ name: Publish SDK to CocoaPods
 
 on:
   push:
+    tags:
+      - '*'
 
 jobs:
   publish:

--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - '*'
 
 jobs:
   publish:
@@ -11,13 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ruby/setup-ruby@v1
+
       - name: Install Cocoapods
         run: gem install cocoapods
 
-      - name: Deploy to Cocoapods
-        run: |
-          set -eo pipefail
-          pod lib lint --allow-warnings
-          pod trunk push --allow-warnings
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      # - name: Deploy to Cocoapods
+      #   run: |
+      #     set -eo pipefail
+      #     pod lib lint --allow-warnings
+      #     pod trunk push --allow-warnings
+      #   env:
+      #     COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -1,0 +1,23 @@
+name: Publish SDK to CocoaPods
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Cocoapods
+        run: gem install cocoapods
+
+      - name: Deploy to Cocoapods
+        run: |
+          set -eo pipefail
+          pod lib lint --allow-warnings
+          pod trunk push --allow-warnings
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -2,10 +2,6 @@ name: Publish SDK to CocoaPods
 
 on:
   push:
-    tags:
-      - "*"
-    branches:
-      - '*'
 
 jobs:
   publish:

--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
 
       - name: Install Cocoapods
         run: gem install cocoapods


### PR DESCRIPTION
Adds a workflow to publish the SDK to CocoaPods on tag create. 

Code obtained from [here](https://github.com/marketplace/actions/deploy-to-cocoapod-action). I've not tested that it works... 