### PR TITLE
chore(ci): update source to look for tag with leading v as created by release please

### DIFF
--- a/FlagsmithClient.podspec
+++ b/FlagsmithClient.podspec
@@ -8,12 +8,14 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FlagsmithClient'
-  s.version          = '3.8.2'  # x-release-please-version
+  # x-release-please-start-version
+  s.version          = '3.8.2'
+  # x-release-please-end
   s.summary          = 'iOS Client written in Swift for Flagsmith. Ship features with confidence using feature flags and remote config.'
   s.homepage         = 'https://github.com/Flagsmith/flagsmith-ios-client'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Kyle Johnson' => 'Kyle.johnson@flagsmith.com' }
-  s.source           = { :git => 'https://github.com/Flagsmith/flagsmith-ios-client.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/Flagsmith/flagsmith-ios-client.git', :tag => "v#{s.version}" }
   s.social_media_url = 'https://twitter.com/getflagsmith'
   s.resource_bundles = {
     'Flagsmith_Privacy' => ['FlagsmithClient/Classes/PrivacyInfo.xcprivacy'],

--- a/FlagsmithClient.podspec
+++ b/FlagsmithClient.podspec
@@ -8,9 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FlagsmithClient'
-  # x-release-please-start-version
-  s.version          = '3.8.2'
-  # x-release-please-end
+  s.version          = '3.8.2'  # x-release-please-version
   s.summary          = 'iOS Client written in Swift for Flagsmith. Ship features with confidence using feature flags and remote config.'
   s.homepage         = 'https://github.com/Flagsmith/flagsmith-ios-client'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
This change resolves the issue seen [here](https://github.com/Flagsmith/flagsmith-ios-client/actions/runs/16372332471) which is caused by the fact that the deployment process looks for the github tag without the leading v, but release please now creates the tag with the (favourable) leading v. 