### PR TITLE
feat: Send a standard User-Agent: sdk-name/version header

### DIFF
--- a/FlagsmithClient/Classes/Internal/Router.swift
+++ b/FlagsmithClient/Classes/Internal/Router.swift
@@ -11,6 +11,11 @@ import Foundation
 #endif
 
 enum Router: Sendable {
+    // x-release-please-start-version
+    private static let sdkVersion = "3.9.0"
+    // x-release-please-end
+    static let userAgent = "flagsmith-swift-ios-sdk/\(sdkVersion)"
+
     private enum HTTPMethod: String {
         case get = "GET"
         case post = "POST"
@@ -102,6 +107,7 @@ enum Router: Sendable {
         }
         request.addValue(apiKey, forHTTPHeaderField: "X-Environment-Key")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(Router.userAgent, forHTTPHeaderField: "User-Agent")
 
         return request
     }

--- a/FlagsmithClient/Classes/Internal/SSEManager.swift
+++ b/FlagsmithClient/Classes/Internal/SSEManager.swift
@@ -157,6 +157,7 @@ final class SSEManager: NSObject, URLSessionDataDelegate, @unchecked Sendable {
         request.setValue("text/event-stream, application/json; charset=utf-8", forHTTPHeaderField: "Accept")
         request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
         request.setValue("keep-alive", forHTTPHeaderField: "Connection")
+        request.setValue(Router.userAgent, forHTTPHeaderField: "User-Agent")
 
         completionHandler = completion
         dataTask = session.dataTask(with: request)

--- a/FlagsmithClient/Tests/RouterTests.swift
+++ b/FlagsmithClient/Tests/RouterTests.swift
@@ -20,6 +20,9 @@ final class RouterTests: FlagsmithClientTestCase {
         XCTAssertEqual(request.url?.absoluteString, "https://edge.api.flagsmith.com/api/v1/flags/")
         XCTAssertTrue(request.allHTTPHeaderFields?.contains(where: { $0.key == "X-Environment-Key" }) ?? false)
         XCTAssertNil(request.httpBody)
+        // x-release-please-start-version
+        XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "flagsmith-swift-ios-sdk/3.9.0")
+        // x-release-please-end
     }
 
     func testGetIdentityRequest() throws {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,9 @@
             "prerelease": false,
             "include-component-in-tag": false,
             "extra-files": [
-                "FlagsmithClient.podspec"
+                "FlagsmithClient.podspec",
+                "FlagsmithClient/Classes/Internal/Router.swift",
+                "FlagsmithClient/Tests/RouterTests.swift"
             ]
         }
     },


### PR DESCRIPTION
The Flagsmith API cannot currently distinguish which SDK or version is making requests from this client. This is part of a cross-SDK effort to standardize User-Agent headers — Kotlin Android (https://github.com/Flagsmith/flagsmith-kotlin-android-client/pull/83) and Flutter (https://github.com/Flagsmith/flagsmith-flutter-client/pull/85) already ship theirs. The version strategy follows the release-please approach decided during review of #95 (https://github.com/Flagsmith/flagsmith-ios-client/pull/95#discussion_r2518330211).

## Changes

- [x] Every outbound HTTP request (REST API and real-time) identifies the SDK and its version
- [x] SDK version stays current automatically after each release

Supersedes #95
Closes #88

Review effort: 1/5